### PR TITLE
Sort all Google events by chronological order

### DIFF
--- a/src/event_processor.py
+++ b/src/event_processor.py
@@ -142,7 +142,9 @@ class EventProcessor(object):
 
         o = 0
         g = 0
-
+        
+        # Sort all Google events from all calendars by chronological order
+        google_events.sort(key=lambda r: r['start'].get('dateTime'))
 
         while g < google_count and o < outlook_count:
 


### PR DESCRIPTION
Currently, events are kept adjacent to other events in their respective Google calendars.
This line interweaves Google events irrespective of parent calendar.

_Note: ignore the graphics, they're from my tweaked fork_

## Before:
![image](https://user-images.githubusercontent.com/602352/30754884-2dfc3c2a-9fcd-11e7-8dfc-a804ed391928.png)

## After
![image](https://user-images.githubusercontent.com/602352/30754914-4b0b6570-9fcd-11e7-86df-9b4627e5a64b.png)
